### PR TITLE
Fixes volume error when file in the root folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
 
         ## set the input parameters for the action
         with:
-          flag-file: ${{ github.workspace }}/config/flag-config.yaml
+          flag-file: ./config/flag-config.yaml
           format: yaml
 ```
 

--- a/run-lint.sh
+++ b/run-lint.sh
@@ -64,10 +64,11 @@ configDir=$(dirname "$flagFile")
 configFile=$(basename "$flagFile")
 
 ## Run the linter against the config file
-msg=$(docker run -v "${configDir}":/config --rm --name gofeatureflag_lint \
+msg=$( { docker run -v "${configDir}":/config --rm --name gofeatureflag_lint \
             thomaspoignant/go-feature-flag-lint \
             --input-format="$2" \
-            --input-file=/config/"${configFile}")
+            --input-file=/config/"${configFile}"; } 2>&1)
+
 
 ## Check if the linter has any errors
 if [[ $? != 0 || ! -z "${msg}" ]]; then

--- a/run-lint.sh
+++ b/run-lint.sh
@@ -1,4 +1,5 @@
 # Reset
+GO_FEATURE_FLAG_LINT_DOCKER_TAG="v1"
 Color_Off='\033[0m'       # Text Reset
 
 # Regular Colors
@@ -34,6 +35,10 @@ function fmtPrintln() {
     esac
 }
 
+## Get the latest image of go-feature-flag-lint from source
+fmtPrintln "info" "pulling the latest image of go-feature-flag-lint from source"
+docker pull thomaspoignant/go-feature-flag-lint:${GO_FEATURE_FLAG_LINT_DOCKER_TAG}
+
 ## Input arguments
 fmtPrintln "info" "input arguments: $1 and $2"
 
@@ -61,9 +66,9 @@ configFile=$(basename "$flagFile")
 
 ## Run the linter against the config file
 msg=$( { docker run -v "${configDir}":/config --rm --name gofeatureflag_lint \
-            thomaspoignant/go-feature-flag-lint:v1 \
+            thomaspoignant/go-feature-flag-lint:${GO_FEATURE_FLAG_LINT_DOCKER_TAG} \
             --input-format="$2" \
-            --input-file=/config/"${configFile}"; } 2>&1 > /dev/null)
+            --input-file=/config/"${configFile}"; } 2>&1)
 
 
 ## Check if the linter has any errors

--- a/run-lint.sh
+++ b/run-lint.sh
@@ -63,7 +63,7 @@ configFile=$(basename "$flagFile")
 msg=$( { docker run -v "${configDir}":/config --rm --name gofeatureflag_lint \
             thomaspoignant/go-feature-flag-lint:v1 \
             --input-format="$2" \
-            --input-file=/config/"${configFile}"; } 2>&1)
+            --input-file=/config/"${configFile}"; } 2>&1 > /dev/null)
 
 
 ## Check if the linter has any errors

--- a/run-lint.sh
+++ b/run-lint.sh
@@ -65,7 +65,7 @@ configFile=$(basename "$flagFile")
 
 ## Run the linter against the config file
 msg=$( { docker run -v "${configDir}":/config --rm --name gofeatureflag_lint \
-            thomaspoignant/go-feature-flag-lint \
+            thomaspoignant/go-feature-flag-lint@v1 \
             --input-format="$2" \
             --input-file=/config/"${configFile}"; } 2>&1)
 

--- a/run-lint.sh
+++ b/run-lint.sh
@@ -34,10 +34,6 @@ function fmtPrintln() {
     esac
 }
 
-## Get the latest image of go-feature-flag-lint from source
-fmtPrintln "info" "pulling the latest image of go-feature-flag-lint from source"
-docker pull thomaspoignant/go-feature-flag-lint:latest
-
 ## Input arguments
 fmtPrintln "info" "input arguments: $1 and $2"
 
@@ -65,7 +61,7 @@ configFile=$(basename "$flagFile")
 
 ## Run the linter against the config file
 msg=$( { docker run -v "${configDir}":/config --rm --name gofeatureflag_lint \
-            thomaspoignant/go-feature-flag-lint \
+            thomaspoignant/go-feature-flag-lint:v1 \
             --input-format="$2" \
             --input-file=/config/"${configFile}"; } 2>&1)
 

--- a/run-lint.sh
+++ b/run-lint.sh
@@ -35,8 +35,8 @@ function fmtPrintln() {
     esac
 }
 
-## Get the latest image of go-feature-flag-lint from source
-fmtPrintln "info" "pulling the latest image of go-feature-flag-lint from source"
+## Get the image of go-feature-flag-lint from source
+fmtPrintln "info" "pulling the image of go-feature-flag-lint:${GO_FEATURE_FLAG_LINT_DOCKER_TAG} from source"
 docker pull thomaspoignant/go-feature-flag-lint:${GO_FEATURE_FLAG_LINT_DOCKER_TAG}
 
 ## Input arguments

--- a/run-lint.sh
+++ b/run-lint.sh
@@ -65,7 +65,7 @@ configFile=$(basename "$flagFile")
 
 ## Run the linter against the config file
 msg=$( { docker run -v "${configDir}":/config --rm --name gofeatureflag_lint \
-            thomaspoignant/go-feature-flag-lint@v1 \
+            thomaspoignant/go-feature-flag-lint \
             --input-format="$2" \
             --input-file=/config/"${configFile}"; } 2>&1)
 

--- a/run-lint.sh
+++ b/run-lint.sh
@@ -59,8 +59,10 @@ if [[ "$2" != "yaml" && "$2" != "json" && "$2" != "toml" ]]; then
     exit 1
 fi
 
-configDir=$(dirname "$1")
-configFile=$(basename "$1")
+flagFile="$(pwd)/$1"
+configDir=$(dirname "$flagFile")
+configFile=$(basename "$flagFile")
+
 ## Run the linter against the config file
 msg=$(docker run -v "${configDir}":/config --rm --name gofeatureflag_lint \
             thomaspoignant/go-feature-flag-lint \

--- a/run-lint.sh
+++ b/run-lint.sh
@@ -78,4 +78,3 @@ if [[ $? != 0 || ! -z "${msg}" ]]; then
 fi
 
 fmtPrintln "info" "linting passed"
-exit 0


### PR DESCRIPTION
# Description
When the flag was in the root folder of the repo we had the error
```shell
docker: Error response from daemon: create .: volume name is too short, names should be at least two alphanumeric characters.
```
This PR uses the current folder as a base location to get the flag file.

see failing job: https://github.com/thomaspoignant/test-gha/actions/runs/4880143398/jobs/8707429567

**Some other small fixes in this PR:**
- errors were not added to the variable `msg`.
- `exit 0` is not needed because this is the default behavior in bash.
- Stick the container to `v1`.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)

# Checklist
- [x] I have tested this code
